### PR TITLE
Fix bug in the array decoder

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -167,10 +167,10 @@ NEXT_ELEMENT:
         arrlen[depth]++;
         lua_rawseti(L, -2, arrlen[depth]);
     }
-    str = decode_skip_space(str);
 
 CHECK_DELIMITER:
     // next delimiter must be ',' or '}'
+    str = decode_skip_space(str);
     if (*str == ',') {
         str = decode_skip_space(str + 1);
     } else if (*str != '}') {

--- a/test/array_test.lua
+++ b/test/array_test.lua
@@ -8,6 +8,7 @@ function testcase.array()
                        function(elmstr)
             return elmstr
         end)
+    assert.is_nil(err)
     assert.equal(v, {
         'foo',
         nil,
@@ -22,7 +23,16 @@ function testcase.array()
         '"quux"',
         '"hello\\ world!"',
     })
+
+    -- test that NULL elements
+    v, err = decode_array('{ foo, bar, NULL }', function(elmstr)
+        return elmstr
+    end)
     assert.is_nil(err)
+    assert.equal(v, {
+        'foo',
+        'bar',
+    })
 
     -- test that can ignore elements
     v, err = decode_array('{ foo, (bar), baz }', function(elmstr)


### PR DESCRIPTION
an error occur because whitespaces are not skipped after parsing unquoted elements.